### PR TITLE
Update CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,35 +4,40 @@
 
 Deployed to https://rfcbot.rs right now.
 
+## Code of Conduct
+
+All contributors are expected to follow our [Code of Conduct][conduct].
+
 ## Development
 
 ### Chat
 
-There is an `#rfcbot` channel in the `ops` section of the [rust-lang discord server](https://discordapp.com/invite/rust-lang).
+There is an `#rfcbot` channel in the `ops` section of the 
+[rust-lang discord server](https://discordapp.com/invite/rust-lang).
 
 ### Rust Version
 
-Rust nightly is required, as rfcbot uses [Rocket](rocket.rs). If you use rustup, this version is managed for you by a `rust-toolchain` file at the repository root.
+Rust nightly is required, as rfcbot uses [Rocket](rocket.rs). If you use rustup, this version is 
+managed for you by a `rust-toolchain` file at the repository root.
 
 ### Running locally
 
-Install [Docker](https://docker.dom) and [docker-compose](https://docs.docker.com/compose) and ensure they're working.
+Install [Docker](https://docker.dom) and [docker-compose](https://docs.docker.com/compose) and 
+ensure they're working.
 
-Next, start development services and initialize the database:
+Next, start development services and initialize the database with `docker-compose up`.
 
-```
-cargo install diesel_cli
-docker-compose up -d
-./setup-db.sh
-```
+Press `Ctrl+C` to exit the server process. The container build is not (yet?) aware of how to detect
+changes to source files, so once you have made changes you will need to run `docker-compose build`
+before running `docker-compose up` to see your changes take effect.
 
-After this you may need to run `docker-compose down`/`docker-compose up -d` for the server process to see the database updates.
-
-By default this stores your database files in `target/data/`, so any temporary changes you make to the database will be removed by a `cargo clean` and you'll need to run the above commands again.
+By default this stores your database files in `target/data/`, so any temporary changes you make to 
+the database will be removed by a `cargo clean` and you'll need to run the above commands again.
 
 ### Database dumps
 
-It can be useful to have a database with some existing data to start from. "Bootstrap" files are available at https://www.dropbox.com/sh/dl4pxj1d49ici1f/AAAzZQxWVqQzVk_zOksn0Rbya?dl=0.
+It can be useful to have a database with some existing data to start from. "Bootstrap" files are 
+available at https://www.dropbox.com/sh/dl4pxj1d49ici1f/AAAzZQxWVqQzVk_zOksn0Rbya?dl=0.
 
 Assuming that you download the most recent file in the above folder and name it `bootstrap.sql`:
 
@@ -43,12 +48,12 @@ psql -d $DATABASE_URL -f bootstrap.sql
 
 ## Deployment
 
-Deployed to Heroku via TravisCI from the master branch. See (.travis.yml)[./travis.yml] for an up-to-date listing of the actions.
-
-## Conduct
-
-This project has a [Code of Conduct and moderation policy](https://github.com/rust-lang/rfcbot-rs/blob/master/CONDUCT.md) very similar to the Rust CoC.
+Deployed to Heroku via TravisCI from the master branch. See [.travis.yml](./travis.yml) for an 
+up-to-date listing of the actions.
 
 ## License
 
-This project is distributed under the terms of both the MIT license and the Apache License (Version 2.0). See LICENSE-MIT and LICENSE-APACHE for details.
+This project is distributed under the terms of both the MIT license and the Apache License 
+(Version 2.0). See LICENSE-MIT and LICENSE-APACHE for details.
+
+[conduct]: https://www.rust-lang.org/conduct.html

--- a/setup-db.sh
+++ b/setup-db.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -xe
-
 DATABASE_URL="${DATABASE_URL:-postgres://postgres:ughfineokifitsfordebugging@localhost:54320/rfcbot}"
 
 until psql -d "$DATABASE_URL" -c '\q'; do
@@ -11,8 +9,17 @@ done
 
 >&2 echo "Postgres is up - executing commands"
 
+set -e
 diesel database setup
 diesel migration run
-psql -q -d "$DATABASE_URL" --file ./githubuser-backup.pg
+set +e
+
+sql_output="$(psql -q -d "$DATABASE_URL" --file ./githubuser-backup.pg)"
+sql_status="$?"
+
+if [ ! $sql_status ]; then
+  echo "$sql_output"
+  exit $sql_status
+fi
 
 exec "$@"


### PR DESCRIPTION
I've landed a couple of PRs reviving rfcbot's deployment and integration testing, ultimately using docker and then docker-compose (for postgres):

https://github.com/rust-lang/rfcbot-rs/pull/281
https://github.com/rust-lang/rfcbot-rs/pull/283

This results in a (I hope) much simpler local development flow and easier local replication of CI results.

@Centril @pietroalbini I'm trimming the contributing guide down to reflect his, do you feel like there's enough here that you could manually test a commit in a browser if you needed? What is missing to achieve that goal?