### PR TITLE
Change FCP close message to allow for non-RFC FCPs

### DIFF
--- a/src/github/nag.rs
+++ b/src/github/nag.rs
@@ -1253,13 +1253,13 @@ impl<'a> RfcBotComment<'a> {
 
                 match disposition {
                     FcpDisposition::Merge => {
-                        msg.push_str("\n\nThe RFC will be merged soon.");
+                        msg.push_str("\n\nThis will be merged soon.");
                     }
                     FcpDisposition::Close if can_ffcp_close(issue) => {
-                        msg.push_str("\n\nThe RFC is now closed.");
+                        msg.push_str("\n\nThis is now closed.");
                     }
                     FcpDisposition::Postpone if can_ffcp_postpone(issue) => {
-                        msg.push_str("\n\nThe RFC is now postponed.");
+                        msg.push_str("\n\nThis is now postponed.");
                     }
                     _ => {}
                 }


### PR DESCRIPTION
These days, FCPs are most commonly used in contexts other than RFCs. Of the [17 currently open FCPs](https://rfcbot.rs), 3 are in `rust-lang/rfcs` and 14 are in other `rust-lang` repositories. Mostly rfcbot handles this fine, but it's a bit disconcerting that when it's closing an FCP it says "the RFC", even if the thing it's dealing with isn't one. Everywhere else, it just says "this", but for some reason the termination message is handedly differently. This PR updates the message to describe the thing being FCPed more neutrally.