### PR TITLE
Remove "only one command per comment" note

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ rfcbot accepts commands in GitHub comments. All commands take the form:
 @rfcbot COMMAND [PARAMS]
 ```
 
-The bot expects one command per comment, and the command must start on its own line, but otherwise the bot doesn't care if there's other text in the comment. This is valid:
+The bot expects one command per line, and the command must start on its own line, but otherwise the bot doesn't care if there's other text in the comment. This is valid:
 
 ```
 TEXT
@@ -29,13 +29,6 @@ But this is not:
 ```
 TEXT @rfcbot fcp merge
 TEXT
-```
-
-Only the first of these commands will be registered:
-
-```
-@rfcbot concern FOO
-@rfcbot concern BAR
 ```
 
 Examples are in each section.

--- a/src/github/command.rs
+++ b/src/github/command.rs
@@ -291,6 +291,8 @@ mod test {
         let text = r#"
 someothertext
 @rfcbot: resolved CONCERN_NAME
+texttexttext
+@rfcbot: resolved SECOND_CONCERN
 somemoretext
 
 somemoretext
@@ -304,6 +306,7 @@ foobar
             parse_commands(text).collect::<Vec<_>>(),
             vec![
                 RfcBotCommand::ResolveConcern("CONCERN_NAME"),
+                RfcBotCommand::ResolveConcern("SECOND_CONCERN"),
                 RfcBotCommand::FcpCancel,
                 RfcBotCommand::NewConcern("foobar"),
             ]


### PR DESCRIPTION
This seems to contradict "multiple occurrences of `grammar`" and
`rfcbot_rs::github::command::test::multiple_commands`.

It looks like #211, that should have made the note obsolete, forgot to
remove it.

I added another example in the test just to make absolutely sure it can take the same command type twice, which it does.