### PR TITLE
Continue showing active FCPs in individual nags

### DIFF
--- a/src/nag.rs
+++ b/src/nag.rs
@@ -102,7 +102,7 @@ pub fn individual_nags(username: &str) -> DashResult<(GitHubUser, Vec<Individual
 
     let review_requests = fcp_review_request::table
         .inner_join(fcp_proposal::table)
-        .filter(fcp_proposal::fcp_start.is_null())
+        .filter(fcp_proposal::fcp_closed.eq(false))
         .filter(fcp_review_request::fk_reviewer.eq(user.id))
         .filter(fcp_review_request::reviewed.eq(false))
         .load::<(FcpReviewRequest, FcpProposal)>(conn)?;


### PR DESCRIPTION
I'd really like to see RFCs in active final comment period that I haven't reviewed yet. Especially since now is my last chance to review them!

The current filter was originally added to address #212; I think this filter would have addressed that concern as well.