### PR TITLE
Add count of reviews and concerns to /api/<username>

### DIFF
--- a/src/nag.rs
+++ b/src/nag.rs
@@ -90,6 +90,8 @@ pub struct IndividualFcp {
     issue: Issue,
     proposal: FcpProposal,
     review_request: FcpReviewRequest,
+    reviews_given: i32,
+    reviews_requested: i32,
 }
 
 pub fn individual_nags(username: &str) -> DashResult<(GitHubUser, Vec<IndividualFcp>)> {
@@ -113,10 +115,18 @@ pub fn individual_nags(username: &str) -> DashResult<(GitHubUser, Vec<Individual
             .filter(issue::id.eq(proposal.fk_issue))
             .first::<Issue>(conn)?;
 
+        let reviews = fcp_review_request::table
+            .filter(fcp_review_request::fk_proposal.eq(proposal.id))
+            .load::<FcpReviewRequest>(conn)?;
+        let reviews_given = reviews.iter().filter(|r| r.reviewed).count() as i32;
+        let reviews_requested = reviews.len() as i32;
+
         fcps.push(IndividualFcp {
             issue,
             proposal,
             review_request: rr,
+            reviews_given,
+            reviews_requested,
         });
     }
 

--- a/src/nag.rs
+++ b/src/nag.rs
@@ -92,6 +92,7 @@ pub struct IndividualFcp {
     review_request: FcpReviewRequest,
     reviews_given: i32,
     reviews_requested: i32,
+    unresolved_concerns: i32,
 }
 
 pub fn individual_nags(username: &str) -> DashResult<(GitHubUser, Vec<IndividualFcp>)> {
@@ -121,12 +122,19 @@ pub fn individual_nags(username: &str) -> DashResult<(GitHubUser, Vec<Individual
         let reviews_given = reviews.iter().filter(|r| r.reviewed).count() as i32;
         let reviews_requested = reviews.len() as i32;
 
+        let unresolved_concerns = fcp_concern::table
+            .filter(fcp_concern::fk_proposal.eq(proposal.id))
+            .filter(fcp_concern::fk_resolved_comment.is_not_null())
+            .count()
+            .get_result::<i64>(conn)? as i32;
+
         fcps.push(IndividualFcp {
             issue,
             proposal,
             review_request: rr,
             reviews_given,
             reviews_requested,
+            unresolved_concerns,
         });
     }
 


### PR DESCRIPTION
This helps a user prioritize their requests by seeing how close each of them is to being accepted.