### PR TITLE
support mentioning rust-rfcbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 >
 > The new account used by the bot is [rust-rfcbot](https://github.com/rust-rfcbot).
 >
-> You still need to ping the old account, i.e. `@rfcbot`.
+> You can mention either `@rfcbot` or `@rust-rfcbot`.
 
-[rfcbot](https://github.com/rfcbot) manages asynchronous decision making on Rust issues and PRs. Status of Final Comment Periods can be viewed on [the relevant dashboard page](http://rfcbot.rs).
+[rust-rfcbot](https://github.com/rust-rfcbot) manages asynchronous decision making on Rust issues and PRs. Status of Final Comment Periods can be viewed on [the relevant dashboard page](http://rfcbot.rs).
 
 It listens for commands on all repositories owned by the [rust-lang](https://github.com/rust-lang), [rust-lang-nursery](https://github.com/rust-lang-nursery), and [rust-lang-deprecated](https://github.com/rust-lang-deprecated) organizations.
 
@@ -16,10 +16,11 @@ While its intended usage is for RFCs, you can use its tracking on any issue or p
 
 ## Usage
 
-rfcbot accepts commands in GitHub comments. All commands take the form:
+rfcbot accepts commands in GitHub comments. All commands take one of the following forms:
 
 ```
 @rfcbot COMMAND [PARAMS]
+@rust-rfcbot COMMAND [PARAMS]
 ```
 
 Each command must start on its own line, but otherwise the bot doesn't care if there's other text in the comment. This is valid:

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,8 @@
 use std::collections::BTreeMap;
 use std::env;
 
-pub const RFC_BOT_MENTION: &str = "@rfcbot";
+/// All valid mention handles that should trigger rfcbot.
+pub const RFC_BOT_MENTIONS: [&str; 2] = ["@rfcbot", "@rust-rfcbot"];
 pub const GH_ORGS: [&str; 3] = ["rust-lang", "rust-lang-nursery", "rust-lang-deprecated"];
 
 lazy_static! {


### PR DESCRIPTION
We have a new user now. This PR adds support for mentioning that user as well.
I haven't tested this.