### PR TITLE
clarify RFC's merging process in disposition to merge message

### DIFF
--- a/src/github/nag.rs
+++ b/src/github/nag.rs
@@ -1304,7 +1304,7 @@ impl<'a> RfcBotComment<'a> {
 
                 match disposition {
                     FcpDisposition::Merge => {
-                        msg.push_str("\n\nThis will be merged soon.");
+                        // No message in this case
                     }
                     FcpDisposition::Close if can_ffcp_close(issue) => {
                         msg.push_str("\n\nThis is now closed.");


### PR DESCRIPTION
current wording implies a false feeling that this will be automatically merged by rfcbot, but it's not true, I was also confused by this on my first PR that went through RFC

I feel like new wording is a bit more precise that this won't be automatic merged, but if you have any other ideas for how to achieve removing this false feeling I'm open to suggestions!

cc @Noratrieb

fixes https://github.com/rust-lang/rfcbot-rs/issues/339
