### PR TITLE
fcp team name parsing: skip empty team names

### DIFF
--- a/src/github/command.rs
+++ b/src/github/command.rs
@@ -179,7 +179,7 @@ fn parse_fcp_subcommand<'a>(
             let team_text = parse_command_text(command, subcommand);
 
             let mut teams = BTreeSet::new();
-            for team_candidate in team_text.split(",") {
+            for team_candidate in team_text.split(",").filter(|s| !s.is_empty()) {
                 let Some(team) = match_team_candidate(setup, team_candidate) else {
                     return Err(DashError::CommentableError(format!("Provided team `{}` is invalid", team_candidate)));
                 };


### PR DESCRIPTION
Whoever wrote this code apparently did not realize that `split` always returns at least one result. That makes the later `teams.is_empty()` check kind of pointless and leads to strange error messages.

Fix that by filtering away empty strings. This means `rfcbot merge` will  look up the teams via the labels, but `rfcbot merge team1,team2` will use the given teams.
Fixes https://github.com/rust-lang/rfcbot-rs/issues/343

Note that I only build-tested this, I don't have a setup to actually run the bot.