### PR TITLE
fcp merge: allow all known users to start team-specific FCPs

### DIFF
--- a/src/github/nag.rs
+++ b/src/github/nag.rs
@@ -76,9 +76,12 @@ pub fn update_nags(comment: &IssueComment) -> DashResult<()> {
 
         any = true;
 
-        if let RfcBotCommand::StartPoll { .. } = command {
-            // Accept poll requests from any known user.
+        if let RfcBotCommand::StartPoll { .. }
+        | RfcBotCommand::FcpPropose(FcpDispositionData::Merge(Some(_))) = command
+        {
+            // Accept poll requests and "fcp merge team" from any known user.
             if all_team_members.iter().find(|&u| u == &author).is_none() {
+                // FIXME: post an error message in the issue.
                 info!("poll requester ({}) is not a known user", author.login);
                 return Ok(());
             }
@@ -86,6 +89,7 @@ pub fn update_nags(comment: &IssueComment) -> DashResult<()> {
             // Don't accept most bot commands from non-subteam members.
             // Early return because we'll just get here again...
             if subteam_members.iter().find(|&u| u == &author).is_none() {
+                // FIXME: post an error message in the issue.
                 info!(
                     "command author ({}) doesn't appear in any relevant subteams",
                     author.login


### PR DESCRIPTION
Helps with https://github.com/rust-lang/rfcbot-rs/issues/312 for the case of `fcp merge team`. The issue remains unfixed for a plain `fcp merge`.

This PR allows everyone who is on any team to start FCP for any team with the "named team" syntax. IMO this is fine, we trust the people we have on teams so it's not worth checking whether the poster is on one of the teams included in the FCP. Note that already before this PR, anyone who is on a team that is mentioned in a label is allowed to start FCP for any team.

Note that I only build-tested this, I don't have a setup to actually run the bot.