### PR TITLE
Remove `needs-fcp` label when an FCP is started

### DIFF
--- a/src/github/command.rs
+++ b/src/github/command.rs
@@ -16,6 +16,7 @@ pub enum Label {
     DispositionMerge,
     DispositionClose,
     DispositionPostpone,
+    NeedsFCP
 }
 
 impl Label {
@@ -31,6 +32,7 @@ impl Label {
             DispositionMerge => "disposition-merge",
             DispositionClose => "disposition-close",
             DispositionPostpone => "disposition-postpone",
+            NeedsFCP => "needs-fcp"
         }
     }
 }

--- a/src/github/nag.rs
+++ b/src/github/nag.rs
@@ -1356,6 +1356,7 @@ impl<'a> RfcBotComment<'a> {
         if let CommentType::FcpProposed(_, disposition, ..) = self.comment_type {
             let _ = self.issue.add_label(Label::PFCP);
             let _ = self.issue.add_label(disposition.label());
+            let _ = self.issue.remove_label(Label::NeedsFCP);
         }
     }
 


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/157798, bors will refuse to approve a PR that has the `needs-fcp` label. Rfcbot should ideally remove the label when an FCP is started (since that time other labels will start blocking an approval), to avoid us having to remove it manually.

More context: https://rust-lang.zulipchat.com/#narrow/channel/122651-general/topic/PR.20got.20merged.20without.20crater.20.26.20FCP/with/602913353
