### PR TITLE
clear S-waiting-on-fcp when FCP week finished

### DIFF
--- a/src/github/command.rs
+++ b/src/github/command.rs
@@ -7,7 +7,9 @@ use crate::teams::{RfcbotConfig, TeamLabel};
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Label {
+    /// Finished FCP
     FFCP,
+    /// Proposed FCP
     PFCP,
     FCP,
     Postponed,
@@ -16,7 +18,9 @@ pub enum Label {
     DispositionMerge,
     DispositionClose,
     DispositionPostpone,
-    NeedsFCP
+    NeedsFCP,
+    WaitingOnFCP,
+    WaitingOnReview,
 }
 
 impl Label {
@@ -32,7 +36,9 @@ impl Label {
             DispositionMerge => "disposition-merge",
             DispositionClose => "disposition-close",
             DispositionPostpone => "disposition-postpone",
-            NeedsFCP => "needs-fcp"
+            NeedsFCP => "needs-fcp",
+            WaitingOnFCP => "S-waiting-on-fcp",
+            WaitingOnReview => "S-waiting-on-review",
         }
     }
 }

--- a/src/github/nag.rs
+++ b/src/github/nag.rs
@@ -530,6 +530,8 @@ fn evaluate_ffcps() -> DashResult<()> {
         // Add FFCP label and remove FCP label.
         let label_res = issue.add_label(Label::FFCP);
         issue.remove_label(Label::FCP);
+        issue.remove_label(Label::WaitingOnFCP);
+        let _ = issue.add_label(Label::WaitingOnReview); // fine to ignore errors, not all repos have the label
         let added_label = match label_res {
             Ok(_) => {
                 if let Err(why) = issue.add_label(Label::ToAnnounce) {


### PR DESCRIPTION
Basically every time an FCP passes I forget to manually remove the S-waiting-on-fcp label and then bors complains that I cannot approve the PR yet.
So let's have the bot just automatically remove the label. :)